### PR TITLE
fix: enable applying evaluation only on fraction of traces

### DIFF
--- a/parea/schemas/models.py
+++ b/parea/schemas/models.py
@@ -105,6 +105,7 @@ class TraceLog(Log):
     output_for_eval_metrics: Optional[str] = None
     evaluation_metric_names: Optional[list[str]] = field(factory=list)
     scores: Optional[list[NamedEvaluationScore]] = field(factory=list)
+    apply_eval_frac: Optional[float] = 1.0
     feedback_score: Optional[float] = None
 
     # info filled from decorator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "parea-ai"
 packages = [{ include = "parea" }]
-version = "0.2.52"
+version = "0.2.53"
 description = "Parea python sdk"
 readme = "README.md"
 authors = ["joel-parea-ai <joel@parea.ai>"]


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🆙 Version bump

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/parea-ai/parea-sdk/blob/master/CODE_OF_CONDUCT.md)
  document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/parea-ai/parea-sdk/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
