### PR TITLE
fix(chore) | structure_trace_log_from_api update for float values.

### DIFF
--- a/parea/helpers.py
+++ b/parea/helpers.py
@@ -90,9 +90,20 @@ def structure_trace_log_from_api(d: dict) -> TraceLogTree:
         else:
             return None
 
+    def structure_float_or_none(obj: Any, cl: type) -> Optional[float]:
+        if obj is None:
+            return None
+        try:
+            return float(obj)
+        except (ValueError, TypeError):
+            return None
+
     converter = GenConverter()
     converter.register_structure_hook(Union[str, Dict[str, str], None], structure_union_type)
-    return converter.structure(d, TraceLogTree)
+    converter.register_structure_hook(float, structure_float_or_none)
+    converter.register_structure_hook(Optional[float], structure_float_or_none)
+
+    return converter.structure(d, TraceLog)
 
 
 def structure_trace_logs_from_api(data: List[dict]) -> List[TraceLogTree]:


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->
Basically `structure_trace_log_from_api` wasn't converting the float and optional floats right and I have fixed that. 

Where it was happening?
sometimes when parea is not tracing the llm, the values of the `temp` or `top_n` on the `ModelParam` will remain None and those cases when you use the `structure_trace_log_from_api`, it will raise the converter issue as it can not convert the optional floats.

This change will fix the issue.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->
When parea is not tracking the ModelParam and they are None, `get_experiment_trace_logs` like in this example (`cookbook/evals_and_experiments/list_experiments.py`) won't work.

The error that you would face:

```
converter.structure(d, TraceLog)
  + Exception Group Traceback (most recent call last):
  |   File "ROOT_PATH.venv/lib/python3.10/site-packages/IPython/core/interactiveshell.py", line 3577, in run_code
  |     exec(code_obj, self.user_global_ns, self.user_ns)
  |   File "<ipython-input-14-ee8beb20e161>", line 1, in <module>
  |     converter.structure(d, TraceLog)
  |   File "ROOT_PATH.venv/lib/python3.10/site-packages/cattrs/converters.py", line 332, in structure
  |     return self._structure_func.dispatch(cl)(obj, cl)
  |   File "<cattrs generated structure parea.schemas.models.TraceLog>", line 232, in structure_TraceLog
  |     if errors: raise __c_cve('While structuring ' + 'TraceLog', errors, __cl)
  | cattrs.errors.ClassValidationError: While structuring TraceLog (1 sub-exception)
  +-+---------------- 1 ----------------
    | Exception Group Traceback (most recent call last):
    |   File "<cattrs generated structure parea.schemas.models.TraceLog>", line 6, in structure_TraceLog
    |     res['configuration'] = __c_structure_configuration(o['configuration'], __c_type_configuration)
    |   File "<cattrs generated structure parea.schemas.log.LLMInputs>", line 40, in structure_LLMInputs
    |     if errors: raise __c_cve('While structuring ' + 'LLMInputs', errors, __cl)
    | cattrs.errors.ClassValidationError: While structuring LLMInputs (1 sub-exception)
    | Structuring class TraceLog @ attribute configuration
    +-+---------------- 1 ----------------
      | Exception Group Traceback (most recent call last):
      |   File "<cattrs generated structure parea.schemas.log.LLMInputs>", line 18, in structure_LLMInputs
      |     res['model_params'] = __c_structure_model_params(o['model_params'], __c_type_model_params)
      |   File "ROOT_PATH.venv/lib/python3.10/site-packages/cattrs/converters.py", line 627, in _structure_optional
      |     return self._structure_func.dispatch(other)(obj, other)
      |   File "<cattrs generated structure parea.schemas.log.ModelParams>", line 46, in structure_ModelParams
      |     if errors: raise __c_cve('While structuring ' + 'ModelParams', errors, __cl)
      | cattrs.errors.ClassValidationError: While structuring ModelParams (4 sub-exceptions)
      | Structuring class LLMInputs @ attribute model_params
      +-+---------------- 1 ----------------
        | Traceback (most recent call last):
        |   File "<cattrs generated structure parea.schemas.log.ModelParams>", line 6, in structure_ModelParams
        |     res['temp'] = __c_structure_temp(o['temp'])
        | TypeError: float() argument must be a string or a real number, not 'NoneType'
        | Structuring class ModelParams @ attribute temp
        +---------------- 2 ----------------
        | Traceback (most recent call last):
        |   File "<cattrs generated structure parea.schemas.log.ModelParams>", line 12, in structure_ModelParams
        |     res['top_p'] = __c_structure_top_p(o['top_p'])
        | TypeError: float() argument must be a string or a real number, not 'NoneType'
        | Structuring class ModelParams @ attribute top_p
        +---------------- 3 ----------------
        | Traceback (most recent call last):
        |   File "<cattrs generated structure parea.schemas.log.ModelParams>", line 18, in structure_ModelParams
        |     res['frequency_penalty'] = __c_structure_frequency_penalty(o['frequency_penalty'])
        | TypeError: float() argument must be a string or a real number, not 'NoneType'
        | Structuring class ModelParams @ attribute frequency_penalty
        +---------------- 4 ----------------
        | Traceback (most recent call last):
        |   File "<cattrs generated structure parea.schemas.log.ModelParams>", line 24, in structure_ModelParams
        |     res['presence_penalty'] = __c_structure_presence_penalty(o['presence_penalty'])
        | TypeError: float() argument must be a string or a real number, not 'NoneType'
        | Structuring class ModelParams @ attribute presence_penalty
        +------------------------------------

```


Didn't made the issue, just the fix here.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🆙 Version bump

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/parea-ai/parea-sdk/blob/master/CODE_OF_CONDUCT.md)
  document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/parea-ai/parea-sdk/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
