### PR TITLE
Fix silently incorrect scores in parea/evals (two inverted metrics, eval() on model output)

### DIFF
--- a/parea/evals/dataset_level/balanced_acc.py
+++ b/parea/evals/dataset_level/balanced_acc.py
@@ -11,7 +11,9 @@ def balanced_acc_factory(score_name: str):
         total = defaultdict(int)
         for log in logs:
             if (eval_result := log.get_score(score_name)) is not None:
-                correct[log.target] += int(eval_result.score)
+                # Threshold instead of truncating: int(0.9) is 0, which would report a class as
+                # entirely wrong even though every one of its scores was almost perfect.
+                correct[log.target] += int(eval_result.score >= 0.5)
                 total[log.target] += 1
         recalls = [correct[key] / total[key] for key in correct]
 

--- a/parea/evals/rag/answer_context_faithfulness_statement_level.py
+++ b/parea/evals/rag/answer_context_faithfulness_statement_level.py
@@ -96,9 +96,10 @@ Answer:
         final_answer = "Final verdict for each statement in order:".lower()
         if final_answer in verdicts:
             verdicts = verdicts[verdicts.find(final_answer) + len(final_answer) :]
-            yes_count = sum(0 if "yes" in answer else 1 for answer in verdicts.strip().split(".") if answer != "")
-            return yes_count / len(statements_formatted)
+            yes_count = sum(1 if "yes" in answer else 0 for answer in verdicts.strip().split(".") if answer.strip())
         else:
-            return max(0, output.count("verdict: no")) / len(statements_formatted)
+            # No summary line: fall back to counting the per-statement verdicts in the grader's response.
+            yes_count = max(0, len(statements_formatted) - verdicts.count("verdict: no"))
+        return min(1.0, yes_count / len(statements_formatted))
 
     return answer_context_faithfulness_statement_level

--- a/parea/evals/rag/context_ranking_listwise.py
+++ b/parea/evals/rag/context_ranking_listwise.py
@@ -1,5 +1,7 @@
 from typing import Callable, List, Optional
 
+import re
+
 from parea.evals.utils import call_openai, get_context, ndcg
 from parea.schemas.log import Log
 
@@ -64,9 +66,18 @@ def context_ranking_listwise_factory(
             is_azure=is_azure,
         )
 
-        s = sorted_list.strip("[] ").replace(" ", "")
-        number_strings = s.split(",")
-        return [int(num) for num in number_strings if num.isdigit()]
+        # The prompt numbers the passages starting at 1, and models answer either with bare numbers
+        # ("3, 1, 2") or with the passage names ("Passage3, Passage1, Passage2"), so pull out every
+        # integer and shift it back to a 0-based index.
+        ranked = []
+        for match in re.findall(r"\d+", sorted_list):
+            index = int(match) - 1
+            if 0 <= index < len(contexts) and index not in ranked:
+                ranked.append(index)
+        # Passages the model dropped or mangled keep their original relative order at the end, so
+        # that the result is always a permutation of the contexts.
+        ranked += [i for i in range(len(contexts)) if i not in ranked]
+        return ranked
 
     def progressive_reranking(query: str, contexts: List[str]) -> List[int]:
         """Returns the indices of the contexts in the order of their relevance (most relevant to least relevant)."""
@@ -74,7 +85,7 @@ def context_ranking_listwise_factory(
             return listwise_reranking(query, contexts)
 
         window_size = n_contexts_to_rank
-        window_step = n_contexts_to_rank // 2
+        window_step = max(1, n_contexts_to_rank // 2)
         offset = len(contexts) - window_size
 
         indices = list(range(len(contexts)))
@@ -101,10 +112,20 @@ def context_ranking_listwise_factory(
         question = log.inputs[question_field]
         contexts = get_context(log, context_fields, True)
 
+        if not contexts:
+            return 0.0
+
         reranked_indices = progressive_reranking(question, contexts)
 
         if ranking_measurement == "ndcg":
-            return ndcg(reranked_indices, list(range(len(contexts))))
+            # `reranked_indices[j]` is the index of the j-th most relevant context, so the context the
+            # reranker put first gets the highest relevance grade. The retriever proposed the contexts
+            # in the order 0, 1, ..., n-1, and NDCG measures how well that order agrees with the grades.
+            n_contexts = len(contexts)
+            relevance = [0] * n_contexts
+            for rank, context_index in enumerate(reranked_indices):
+                relevance[context_index] = n_contexts - rank
+            return ndcg(relevance, list(range(n_contexts)))
         else:
             raise NotImplementedError
 

--- a/parea/evals/rag/context_ranking_pointwise.py
+++ b/parea/evals/rag/context_ranking_pointwise.py
@@ -28,14 +28,7 @@ def context_ranking_pointwise_factory(
     Returns:
         Callable[[Log], float]: A function that takes a log as input and returns a score between 0 and 1 indicating
         how well the retrieved context is ranked by their relevancy.
-
-    Raises:
-        ImportError: If numpy is not installed.
     """
-    try:
-        import numpy as np
-    except ImportError:
-        raise ImportError("Please install numpy to use this metric.")
 
     def context_ranking_pointwise(log: Log) -> float:
         """Quantifies if the retrieved context is ranked by their relevancy"""
@@ -76,8 +69,13 @@ verification:""",
             verifications.append(response)
 
         if ranking_measurement == "average_precision":
-            response = [safe_json_loads(item) for item in verifications]
-            response = [int("yes" in resp.get("verdict", " ").lower()) if resp.get("verdict") else np.nan for resp in response]
+            # A missing or unparseable verdict counts as "not relevant"; using NaN here would poison
+            # the sums below and silently turn the whole score into NaN.
+            response = []
+            for item in verifications:
+                parsed = safe_json_loads(item)
+                verdict = parsed.get("verdict") if isinstance(parsed, dict) else None
+                response.append(int("yes" in str(verdict).lower()) if verdict else 0)
             denominator = sum(response) + 1e-10
             numerator = sum([(sum(response[: i + 1]) / (i + 1)) * response[i] for i in range(len(response))])
             return numerator / denominator

--- a/parea/evals/rag/percent_target_supported_by_context.py
+++ b/parea/evals/rag/percent_target_supported_by_context.py
@@ -1,8 +1,9 @@
 from typing import Callable, List, Optional, Union
 
 import re
+import warnings
 
-from parea.evals.utils import call_openai, get_context
+from parea.evals.utils import call_openai, get_context, safe_json_loads
 from parea.schemas.log import Log
 
 
@@ -78,13 +79,17 @@ classification:
             temperature=0.0,
             is_azure=is_azure,
         )
-        pattern = r"\[\s*\{.*?\}(\s*,\s*\{.*?\})*\s*\]"
-        match = re.search(pattern, classification.replace("\n", ""))
-        if match:
-            response = eval(classification)
-            numerator = sum(item.get("Attributed").lower() == "yes" for item in response)
-            return numerator / len(response)
-        else:
-            return 0.0
+        pattern = r"\[\s*\{.*?\}(?:\s*,\s*\{.*?\})*\s*\]"
+        match = re.search(pattern, classification, flags=re.DOTALL)
+        if not match:
+            warnings.warn(f"Could not find a classification in the model response: {classification}")
+            return None
+
+        response = safe_json_loads(match.group(0))
+        if not isinstance(response, list) or not response:
+            return None
+
+        numerator = sum(1 for item in response if isinstance(item, dict) and str(item.get("Attributed", "")).lower() == "yes")
+        return numerator / len(response)
 
     return percent_target_supported_by_context

--- a/parea/evals/utils.py
+++ b/parea/evals/utils.py
@@ -113,8 +113,9 @@ def dcg(y_true, ranking):
     """Discounted cumulative gain (DCG) at rank k."""
     import numpy as np
 
-    y_true = np.asarray(y_true)
-    ranking = np.asarray(ranking)
+    # float, so that 2**rel doesn't silently overflow int64 once there are >62 relevance grades
+    y_true = np.asarray(y_true, dtype=float)
+    ranking = np.asarray(ranking, dtype=int)
     rel = y_true[ranking]
     gains = 2**rel - 1
     discounts = np.log2(np.arange(len(ranking)) + 2)
@@ -128,6 +129,8 @@ def ndcg(y_true, ranking):
     k = len(ranking)
     best_ranking = np.argsort(y_true)[::-1]
     best = dcg(y_true, best_ranking[:k])
+    if best == 0:
+        return 0.0
     return dcg(y_true, ranking) / best
 
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1,0 +1,291 @@
+import itertools
+import json
+import math
+
+import pytest
+
+import parea.evals.rag.answer_context_faithfulness_statement_level as statement_level_module
+import parea.evals.rag.context_ranking_listwise as listwise_module
+import parea.evals.rag.context_ranking_pointwise as pointwise_module
+import parea.evals.rag.percent_target_supported_by_context as percent_supported_module
+from parea.evals.dataset_level.balanced_acc import balanced_acc_factory
+from parea.evals.utils import dcg
+from parea.schemas import EvaluatedLog, EvaluationResult
+from parea.schemas.log import Log
+
+
+def patch_openai(monkeypatch, module, responses):
+    """Make the module's call_openai return `responses`, one per call, in order."""
+    replies = iter(responses)
+    monkeypatch.setattr(module, "call_openai", lambda *args, **kwargs: next(replies))
+
+
+class TestAnswerContextFaithfulnessStatementLevel:
+    STATEMENTS = "Paris is the capital of France.\nFrance is in Europe.\nThe Eiffel Tower is in Paris."
+
+    LOG = Log(
+        inputs={"question": "Tell me about France.", "context": "Paris is the capital of France. France is in Europe. The Eiffel Tower is in Paris."},
+        output="Paris is the capital of France. France is in Europe. The Eiffel Tower is in Paris.",
+    )
+
+    @staticmethod
+    def nli_response(final_verdicts: str) -> str:
+        return (
+            "1. Paris is the capital of France.\nExplanation: stated in the context. Verdict: Yes.\n"
+            "2. France is in Europe.\nExplanation: stated in the context. Verdict: Yes.\n"
+            "3. The Eiffel Tower is in Paris.\nExplanation: stated in the context. Verdict: Yes.\n"
+            f"Final verdict for each statement in order: {final_verdicts}"
+        )
+
+    @pytest.mark.parametrize(
+        "final_verdicts, expected",
+        [
+            ("Yes. Yes. Yes.", 1.0),
+            ("No. No. No.", 0.0),
+            ("Yes. No. Yes.", 2 / 3),
+            ("No. Yes. No.", 1 / 3),
+        ],
+    )
+    def test_score_is_the_share_of_supported_statements(self, monkeypatch, final_verdicts, expected):
+        """A fully grounded answer must score 1.0 and a fully hallucinated one 0.0, not the other way round."""
+        patch_openai(monkeypatch, statement_level_module, [self.STATEMENTS, self.nli_response(final_verdicts)])
+
+        score = statement_level_module.answer_context_faithfulness_statement_level_factory()(self.LOG)
+
+        assert score == pytest.approx(expected)
+
+    def test_falls_back_to_the_per_statement_verdicts(self, monkeypatch):
+        """Without the summary line the score must come from the grader's verdicts, not the graded answer."""
+        verdicts_without_summary = "1. Paris is the capital of France. Verdict: Yes.\n2. France is in Europe. Verdict: Yes.\n3. The Eiffel Tower is in Paris. Verdict: No."
+        patch_openai(monkeypatch, statement_level_module, [self.STATEMENTS, verdicts_without_summary])
+
+        score = statement_level_module.answer_context_faithfulness_statement_level_factory()(self.LOG)
+
+        assert score == pytest.approx(2 / 3)
+
+    def test_score_stays_within_the_unit_interval(self, monkeypatch):
+        """A grader that returns more verdicts than there are statements must not push the score above 1."""
+        patch_openai(monkeypatch, statement_level_module, [self.STATEMENTS, self.nli_response("Yes. Yes. Yes. Yes. Yes.")])
+
+        score = statement_level_module.answer_context_faithfulness_statement_level_factory()(self.LOG)
+
+        assert score == pytest.approx(1.0)
+
+
+class TestContextRankingListwise:
+    CONTEXTS = ["ctx a", "ctx b", "ctx c", "ctx d"]
+    LOG = Log(inputs={"question": "What is the capital of France?"}, output=json.dumps(CONTEXTS))
+
+    @staticmethod
+    def reranked_reply(permutation) -> str:
+        """Format a reranking the way the prompt asks for it: 1-based passage names."""
+        return ", ".join(f"Passage{index + 1}" for index in permutation) + "]"
+
+    def score_for(self, monkeypatch, permutation) -> float:
+        patch_openai(monkeypatch, listwise_module, [self.reranked_reply(permutation)])
+        return listwise_module.context_ranking_listwise_factory()(self.LOG)
+
+    def test_agreeing_with_the_retrieved_order_scores_one(self, monkeypatch):
+        """If the reranker leaves the retrieved order untouched, the retrieval was perfectly ranked."""
+        assert self.score_for(monkeypatch, range(len(self.CONTEXTS))) == pytest.approx(1.0)
+
+    def test_reversing_the_retrieved_order_scores_lowest(self, monkeypatch):
+        """The reversed order is the worst possible ranking and must not score better than the perfect one."""
+        perfect = self.score_for(monkeypatch, range(len(self.CONTEXTS)))
+        reversed_order = self.score_for(monkeypatch, reversed(range(len(self.CONTEXTS))))
+
+        assert reversed_order < perfect
+
+    def test_score_decreases_as_the_ranking_gets_worse(self, monkeypatch):
+        """Guards against the metric being inverted: the identity ranking must be the unique maximum."""
+        scores = {permutation: self.score_for(monkeypatch, permutation) for permutation in itertools.permutations(range(len(self.CONTEXTS)))}
+
+        identity = tuple(range(len(self.CONTEXTS)))
+        assert max(scores, key=scores.get) == identity
+        assert min(scores, key=scores.get) == identity[::-1]
+        assert all(0.0 <= score <= 1.0 for score in scores.values())
+
+    @pytest.mark.parametrize(
+        "reply",
+        [
+            "Passage2, Passage1, Passage3, Passage4]",
+            "2, 1, 3, 4]",
+            "[Passage2, Passage1, Passage3, Passage4]",
+            "Sorted Passages = [Passage2, Passage1, Passage3, Passage4]",
+        ],
+    )
+    def test_reply_formats_are_parsed_equivalently(self, monkeypatch, reply):
+        """All of these encode the same 1-based ranking, so they must produce the same score."""
+        patch_openai(monkeypatch, listwise_module, [reply])
+        score = listwise_module.context_ranking_listwise_factory()(self.LOG)
+
+        assert score == pytest.approx(self.score_for(monkeypatch, [1, 0, 2, 3]))
+
+    def test_unusable_reply_still_yields_a_valid_score(self, monkeypatch):
+        """A reply with no ranking in it must not drop contexts or raise; it just leaves the order as retrieved."""
+        patch_openai(monkeypatch, listwise_module, ["I'm sorry, I cannot help with that."])
+
+        score = listwise_module.context_ranking_listwise_factory()(self.LOG)
+
+        assert score == pytest.approx(1.0)
+
+    def test_empty_context_list_scores_zero(self, monkeypatch):
+        patch_openai(monkeypatch, listwise_module, [])
+
+        score = listwise_module.context_ranking_listwise_factory()(Log(inputs={"question": "q"}, output=json.dumps([])))
+
+        assert score == 0.0
+
+    def test_ranking_a_single_context_at_a_time_terminates(self, monkeypatch):
+        """n_contexts_to_rank=1 used to make the sliding window step by 0 and loop forever."""
+        patch_openai(monkeypatch, listwise_module, ["1]"] * 10)
+
+        score = listwise_module.context_ranking_listwise_factory(n_contexts_to_rank=1)(self.LOG)
+
+        assert 0.0 <= score <= 1.0
+
+
+class TestContextRankingPointwise:
+    LOG = Log(inputs={"question": "What is the capital of France?"}, output=json.dumps(["ctx a", "ctx b", "ctx c"]))
+
+    @pytest.mark.parametrize(
+        "verdicts, expected",
+        [
+            (["Yes", "Yes", "Yes"], 1.0),
+            (["No", "No", "No"], 0.0),
+            (["Yes", "No", "Yes"], (1 / 1 + 2 / 3) / 2),
+        ],
+    )
+    def test_average_precision_matches_the_manual_calculation(self, monkeypatch, verdicts, expected):
+        patch_openai(monkeypatch, pointwise_module, [json.dumps({"reason": "...", "verdict": verdict}) for verdict in verdicts])
+
+        score = pointwise_module.context_ranking_pointwise_factory()(self.LOG)
+
+        assert score == pytest.approx(expected)
+
+    @pytest.mark.parametrize(
+        "malformed",
+        [
+            "I cannot answer that.",
+            json.dumps({"reason": "unsure"}),
+            "",
+        ],
+    )
+    def test_a_malformed_verdict_does_not_produce_nan(self, monkeypatch, malformed):
+        """One unparseable response used to turn the entire score into NaN."""
+        patch_openai(monkeypatch, pointwise_module, [json.dumps({"verdict": "Yes"}), malformed, json.dumps({"verdict": "Yes"})])
+
+        score = pointwise_module.context_ranking_pointwise_factory()(self.LOG)
+
+        assert not math.isnan(score)
+        assert 0.0 <= score <= 1.0
+
+
+class TestPercentTargetSupportedByContext:
+    LOG = Log(inputs={"question": "Tell me about Einstein."}, output="Einstein was a physicist.", target="Einstein was a physicist. He won a Nobel Prize.")
+
+    @staticmethod
+    def classification(*attributions) -> str:
+        items = [{f"statement_{i + 1}": "...", "reason": "...", "Attributed": attributed} for i, attributed in enumerate(attributions)]
+        return json.dumps(items, indent=4)
+
+    @pytest.mark.parametrize(
+        "attributions, expected",
+        [
+            (("Yes", "Yes"), 1.0),
+            (("No", "No"), 0.0),
+            (("Yes", "No", "Yes"), 2 / 3),
+        ],
+    )
+    def test_score_is_the_share_of_attributed_statements(self, monkeypatch, attributions, expected):
+        patch_openai(monkeypatch, percent_supported_module, [self.classification(*attributions)])
+
+        score = percent_supported_module.percent_target_supported_by_context_factory()(self.LOG)
+
+        assert score == pytest.approx(expected)
+
+    def test_json_wrapped_in_prose_is_parsed(self, monkeypatch):
+        """Models routinely wrap their answer in a code fence, which used to raise inside eval()."""
+        patch_openai(monkeypatch, percent_supported_module, [f"Here is the classification:\n```json\n{self.classification('Yes', 'No')}\n```"])
+
+        score = percent_supported_module.percent_target_supported_by_context_factory()(self.LOG)
+
+        assert score == pytest.approx(0.5)
+
+    def test_model_output_is_never_executed(self, monkeypatch, tmp_path):
+        """The classification used to be passed to eval(), so the grader could run arbitrary code."""
+        canary = tmp_path / "canary.txt"
+        payload = f'[{{"statement_1": "...", "Attributed": "Yes"}}] and __import__("pathlib").Path({str(canary)!r}).write_text("executed")'
+        patch_openai(monkeypatch, percent_supported_module, [payload])
+
+        percent_supported_module.percent_target_supported_by_context_factory()(self.LOG)
+
+        assert not canary.exists()
+
+    def test_unparseable_classification_returns_no_score(self, monkeypatch):
+        """Reporting 0.0 here is indistinguishable from 'nothing was supported', so return no score at all."""
+        patch_openai(monkeypatch, percent_supported_module, ["I'm sorry, I cannot help with that."])
+
+        with pytest.warns(UserWarning):
+            score = percent_supported_module.percent_target_supported_by_context_factory()(self.LOG)
+
+        assert score is None
+
+    def test_missing_target_returns_no_score(self, monkeypatch):
+        patch_openai(monkeypatch, percent_supported_module, [])
+
+        score = percent_supported_module.percent_target_supported_by_context_factory()(Log(inputs={"question": "q"}, output="out"))
+
+        assert score is None
+
+
+class TestBalancedAccuracy:
+    def test_fractional_scores_are_thresholded_not_truncated(self):
+        """int(0.9) is 0, which used to report a class with near-perfect scores as entirely wrong."""
+        logs = [
+            EvaluatedLog(target="a", scores=[EvaluationResult(name="correctness", score=0.9)]),
+            EvaluatedLog(target="a", scores=[EvaluationResult(name="correctness", score=0.8)]),
+            EvaluatedLog(target="b", scores=[EvaluationResult(name="correctness", score=1.0)]),
+        ]
+
+        result = balanced_acc_factory("correctness")(logs)
+
+        assert result.score == pytest.approx(1.0)
+
+    def test_recall_is_averaged_over_classes(self):
+        """Two of three 'a' logs are correct and the single 'b' log is wrong: (2/3 + 0) / 2."""
+        logs = [
+            EvaluatedLog(target="a", scores=[EvaluationResult(name="correctness", score=1.0)]),
+            EvaluatedLog(target="a", scores=[EvaluationResult(name="correctness", score=1.0)]),
+            EvaluatedLog(target="a", scores=[EvaluationResult(name="correctness", score=0.0)]),
+            EvaluatedLog(target="b", scores=[EvaluationResult(name="correctness", score=0.0)]),
+        ]
+
+        result = balanced_acc_factory("correctness")(logs)
+
+        assert result.score == pytest.approx((2 / 3) / 2)
+
+    def test_no_matching_scores_returns_none(self):
+        logs = [EvaluatedLog(target="a", scores=[EvaluationResult(name="other", score=1.0)])]
+
+        assert balanced_acc_factory("correctness")(logs) is None
+
+
+class TestDCG:
+    @pytest.mark.parametrize("relevance", [1, 32, 63, 64, 70, 200])
+    def test_gain_grows_with_relevance(self, relevance):
+        """2**rel was computed on an int64 array, so a relevance grade above 62 silently wrapped to 0."""
+        gain = dcg([relevance], [0])
+
+        assert math.isfinite(gain)
+        assert gain > dcg([relevance - 1], [0])
+
+    def test_a_well_ranked_list_beats_a_badly_ranked_one(self):
+        n_contexts = 70
+        ranking = list(range(n_contexts))
+
+        best_first = dcg(list(range(n_contexts, 0, -1)), ranking)
+        best_last = dcg(list(range(1, n_contexts + 1)), ranking)
+
+        assert math.isfinite(best_first)
+        assert best_first > best_last


### PR DESCRIPTION
## Description

Five eval functions in `parea/evals/` return wrong scores without raising. Two of them are **inverted** — they report a perfect result as a failure and a total failure as perfect. Because these run inside `_make_evaluations`, which swallows exceptions and logs whatever number comes back, nothing surfaces the problem: the experiment completes and the dashboard shows a plausible score that is simply wrong.

Each fix is a separate commit, and each is covered by tests that fail against `main` (22 of the 39 new tests do).

---

### 1. `answer_context_faithfulness_statement_level` — score is inverted 🔴

[`answer_context_faithfulness_statement_level.py#L99`](https://github.com/parea-ai/parea-sdk-py/blob/main/parea/evals/rag/answer_context_faithfulness_statement_level.py#L99)

```python
yes_count = sum(0 if "yes" in answer else 1 for answer in verdicts.strip().split(".") if answer != "")
```

The variable is named `yes_count`, but the ternary yields `0` when the verdict *is* "yes" and `1` otherwise, so it counts **unsupported** statements.

Driving the eval with a scripted grader response:

| grader's final verdicts | expected | `main` |
|---|---|---|
| `Yes. Yes. Yes.` | 1.00 | **0.00** |
| `No. No. No.` | 0.00 | **1.00** |
| `Yes. No. Yes.` | 0.67 | **0.33** |

An answer entirely grounded in the retrieved context is scored as a complete hallucination.

The fallback on line 102, taken whenever the grader omits the `Final verdict for each statement in order:` summary, is wrong in two further ways:

```python
return max(0, output.count("verdict: no")) / len(statements_formatted)
```

`output` is the **answer being graded**, not the grader's response, so the count is essentially always 0 — and it counts *rejections* as if they were supported statements. A fully supported answer whose grader reply lacked the summary line scored `0.0`.

**Fix:** count "yes" verdicts, read the fallback from the grader's response, and clamp to 1.0 (a grader emitting more verdicts than there were statements could otherwise exceed 1).

### 2. `context_ranking_listwise` — NDCG is inverted 🔴

[`context_ranking_listwise.py#L107`](https://github.com/parea-ai/parea-sdk-py/blob/main/parea/evals/rag/context_ranking_listwise.py#L107)

```python
return ndcg(reranked_indices, list(range(len(contexts))))
```

`ndcg(y_true, ranking)` expects `y_true` to be **relevance grades**, but `reranked_indices` is a **permutation of context indices**. The IDCG denominator is `dcg(y_true, argsort(y_true)[::-1])`, which is maximised when that index list is in *descending* order — i.e. when the reranker completely reverses the retrieved order.

All 24 permutations of 4 contexts, against `sklearn.metrics.ndcg_score`:

| `reranked_indices` | `main` | sklearn | |
|---|---|---|---|
| `[0, 1, 2, 3]` | **0.548** | 1.000 | perfect retrieval |
| `[1, 0, 2, 3]` | 0.587 | 0.950 | |
| `[2, 1, 3, 0]` | 0.759 | 0.786 | |
| `[3, 2, 1, 0]` | **1.000** | 0.749 | worst retrieval |

Pearson correlation between the reported score and the correct NDCG: **−0.75**. A perfect retriever scores 0.55; a retriever that returns its results in exactly the wrong order scores 1.0.

**Fix:** convert `reranked_indices` into relevance grades first — the context the reranker placed first gets the highest grade — then measure how well the retrieved order `0..n-1` agrees with them. Perfect retrieval now scores 1.0, and the regression test asserts that over every permutation of four contexts the score is uniquely maximised by the identity ranking and minimised by the reversed one.

Three further bugs on the same path:

- **`listwise_reranking` cannot parse its own prompt's reply format.** The prompt labels passages `Passage1`..`PassageN`, but parsing is `[int(num) for num in s.split(",") if num.isdigit()]`. A reply naming the passages (`Passage3, Passage1, ...`) parses to `[]`, and `contexts[offset:offset + window_size] = []` then **silently deletes that window of contexts**. A reply of bare numbers is 1-based but is used as 0-based indices, producing an off-by-one ranking and an `IndexError` at the window boundary. Now every integer in the reply is extracted, shifted to 0-based, bounds-checked and de-duplicated, with dropped passages appended — the result is always a permutation.
- **`n_contexts_to_rank=1` hangs forever.** The factory validates `n_contexts_to_rank >= 1`, but `window_step = n_contexts_to_rank // 2` is then `0`, so `offset -= window_step` never terminates. Confirmed with a 10s alarm: no progress, and no API call is made inside the loop, so it spins on CPU indefinitely. Now `max(1, n_contexts_to_rank // 2)`.
- **`dcg()` overflows int64.** `gains = 2**rel - 1` on an integer array wraps for any relevance grade above 62 — `dcg([70], [0])` returns `-1.0`, a *negative* gain. This is reachable now that grades scale with the number of retrieved contexts (a top-70 retrieval is ordinary). `ndcg()` also returned NaN rather than 0.0 when nothing was relevant.

### 3. `percent_target_supported_by_context` — `eval()` on model output 🔐

[`percent_target_supported_by_context.py#L84`](https://github.com/parea-ai/parea-sdk-py/blob/main/parea/evals/rag/percent_target_supported_by_context.py#L84)

```python
match = re.search(pattern, classification.replace("\n", ""))
if match:
    response = eval(classification)
```

The grader's reply is passed to `eval()`, so whatever the model emits is executed as Python. A reply of

```
[{"Attributed": "Yes"}] and __import__("pathlib").Path("PWNED.txt").write_text("arbitrary code ran")
```

passes the regex and writes the file before any score is computed. Reachable by prompt injection through retrieved documents, which are attacker-controlled in most RAG deployments.

The regex is not a guard at all: it is applied to `classification.replace("\n", "")` while `eval()` receives the **unmodified** string, so the two never see the same text. That mismatch also breaks the ordinary case — a grader that pretty-prints its JSON or wraps it in a ```` ```json ```` fence raises `SyntaxError` straight out of `eval()`.

**Fix:** parse the matched span with `json.loads` (via the existing `safe_json_loads`) and `re.DOTALL` so multi-line replies match. A missing `Attributed` key no longer raises `AttributeError` on `None`.

Unparseable replies now return `None` instead of `0.0`. `0.0` was indistinguishable from "the context supports none of the target" and was logged as a real score; `None` skips the eval, which the return type already allowed. Happy to revert that part if you'd rather keep 0.0.

### 4. `context_ranking_pointwise` — one bad response makes the score NaN

[`context_ranking_pointwise.py#L80`](https://github.com/parea-ai/parea-sdk-py/blob/main/parea/evals/rag/context_ranking_pointwise.py#L80)

```python
response = [int("yes" in resp.get("verdict", " ").lower()) if resp.get("verdict") else np.nan for resp in response]
```

A verification that is not valid JSON, or that omits `verdict`, becomes `np.nan`, which then poisons both the numerator and the denominator:

```
all well-formed              -> 0.99999999995
one non-JSON reply           -> nan
one reply missing 'verdict'  -> nan
```

The NaN is logged as the score and silently destroys any mean computed over the experiment.

**Fix:** treat an unusable verification as "not relevant", matching RAGAS. numpy is no longer needed, so the import guard and its `Raises:` docstring entry are dropped.

### 5. `balanced_acc` — fractional scores truncated to zero

[`balanced_acc.py#L14`](https://github.com/parea-ai/parea-sdk-py/blob/main/parea/evals/dataset_level/balanced_acc.py#L14)

```python
correct[log.target] += int(eval_result.score)
```

`int()` truncates toward zero, so a class whose scores were all `0.9` is reported as having **0.0** recall. Only an exact `1.0` counts. Now thresholded at `>= 0.5`.

This is the one judgement call in the PR — if you'd prefer `balanced_acc` to reject non-binary scores outright, say so and I'll change it.

---

## Reproducing

Every case above is covered by `tests/test_evals.py`, which drives the eval functions with scripted grader responses via `monkeypatch` — no API calls, no keys, runs in ~0.3s.

```bash
poetry run pytest tests/test_evals.py -q     # 39 passed
git stash && poetry run pytest tests/test_evals.py -q  # 22 failed against main
```

(The `n_contexts_to_rank=1` test hangs on `main` rather than failing, so deselect it when checking against the old code.)

The listwise ranking tests are written as properties rather than fixed numbers — the identity permutation must be the unique maximum and the reversed one the unique minimum — so they catch an inversion regardless of the exact gain formula.

## Related Issue

<!-- none -->

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🔐 Security fix
- [ ] 🆙 Version bump

Marked breaking because scores change — that is the point of the PR. Anything scored with the two inverted metrics needs re-running; historical values for them are not comparable to new ones.

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/parea-ai/parea-sdk/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/parea-ai/parea-sdk/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
