### PR TITLE
fix(experiment): isolate dataset-level evals to the current experiment

### DIFF
--- a/parea/experiment/experiment.py
+++ b/parea/experiment/experiment.py
@@ -55,11 +55,15 @@ def async_wrapper(fn, **kwargs):
     return asyncio.run(fn(**kwargs))
 
 
-def apply_dataset_eval(dataset_level_evals: List[Callable]) -> List[EvaluationResult]:
-    root_traces = []
-    for trace in trace_data.get().values():
-        if trace.root_trace_id == trace.trace_id:
-            root_traces.append(trace)
+def apply_dataset_eval(dataset_level_evals: List[Callable], experiment_uuid: str) -> List[EvaluationResult]:
+    """Run dataset-level evals on root traces that belong to this experiment.
+
+    Trace logs live in a process-wide map that is not cleared between runs, so
+    filtering by experiment_uuid is required. Without it, a later experiment in
+    the same process silently scores leftover traces from earlier experiments
+    and from unrelated tracing.
+    """
+    root_traces = [trace for trace in trace_data.get().values() if trace.root_trace_id == trace.trace_id and trace.experiment_uuid == experiment_uuid]
 
     results = []
     for dataset_level_eval in dataset_level_evals:
@@ -179,7 +183,7 @@ async def experiment(
         pbar.update(total_evals)
 
     if dataset_level_evals:
-        dataset_level_eval_results = apply_dataset_eval(dataset_level_evals)
+        dataset_level_eval_results = apply_dataset_eval(dataset_level_evals, experiment_uuid)
     else:
         dataset_level_eval_results = []
 

--- a/tests/test_dataset_level_eval.py
+++ b/tests/test_dataset_level_eval.py
@@ -1,0 +1,76 @@
+import pytest
+
+from parea.evals.dataset_level.balanced_acc import balanced_acc_factory
+from parea.experiment.experiment import apply_dataset_eval
+from parea.schemas import EvaluationResult
+from parea.schemas.models import TraceLog
+from parea.utils.trace_utils import trace_data
+
+
+def _trace(trace_id, experiment_uuid, *, root_trace_id=None, target="yes", score=1.0, score_name="is_correct"):
+    root = root_trace_id or trace_id
+    return TraceLog(
+        trace_id=trace_id,
+        parent_trace_id=root,
+        root_trace_id=root,
+        start_timestamp="2024-01-01T00:00:00",
+        experiment_uuid=experiment_uuid,
+        target=target,
+        scores=[EvaluationResult(name=score_name, score=score)] if score is not None else [],
+    )
+
+
+@pytest.fixture
+def isolated_trace_store():
+    token = trace_data.set({})
+    try:
+        yield trace_data.get()
+    finally:
+        trace_data.reset(token)
+
+
+def test_dataset_eval_only_receives_root_traces_from_the_current_experiment(isolated_trace_store):
+    isolated_trace_store["prev"] = _trace("prev", "exp-1")
+    isolated_trace_store["curr"] = _trace("curr", "exp-2")
+    isolated_trace_store["child"] = _trace("child", "exp-2", root_trace_id="curr")
+    isolated_trace_store["unrelated"] = _trace("unrelated", None)
+
+    seen = []
+
+    def capture(logs):
+        seen.append([log.trace_id for log in logs])
+        return 1.0
+
+    apply_dataset_eval([capture], "exp-2")
+
+    assert seen == [["curr"]]
+
+
+def test_dataset_eval_score_is_not_contaminated_by_prior_experiment(isolated_trace_store):
+    # Prior experiment was perfect. The current experiment failed every class.
+    # Mixing the two would yield balanced accuracy 0.5 instead of 0.0.
+    isolated_trace_store["old_yes"] = _trace("old_yes", "exp-1", target="yes", score=1.0)
+    isolated_trace_store["old_no"] = _trace("old_no", "exp-1", target="no", score=1.0)
+    isolated_trace_store["new_yes"] = _trace("new_yes", "exp-2", target="yes", score=0.0)
+    isolated_trace_store["new_no"] = _trace("new_no", "exp-2", target="no", score=0.0)
+
+    results = apply_dataset_eval([balanced_acc_factory("is_correct")], "exp-2")
+
+    assert len(results) == 1
+    assert results[0].name == "balanced_acc_is_correct"
+    assert results[0].score == 0.0
+
+
+def test_dataset_eval_with_no_matching_traces_does_not_use_other_experiments(isolated_trace_store):
+    isolated_trace_store["prev"] = _trace("prev", "exp-1")
+
+    seen = []
+
+    def capture(logs):
+        seen.append(len(logs))
+        return None
+
+    results = apply_dataset_eval([capture], "exp-2")
+
+    assert seen == [0]
+    assert results == []


### PR DESCRIPTION
## Description

Dataset-level evals (`balanced_acc`, agreement metrics, custom `dataset_level_evals`) walked **every root trace** in the process-wide `trace_data` map. That map is never cleared between runs, and traces were not filtered by `experiment_uuid`.

So a second `p.experiment(...).run()` in the same process — the normal notebook / cookbook pattern — silently scored leftover traces from earlier experiments and from unrelated `@trace` calls. Dataset-level scores on the dashboard then looked plausible while being computed on the wrong set of logs.

Root traces from experiment B now receive only traces whose `experiment_uuid` matches that run. Child spans are still excluded.

Reproduced before the fix: a store containing `prev` (exp-1), `curr` (exp-2), a child of `curr`, and an unrelated non-experiment trace passed `['prev', 'curr', 'unrelated']` into the dataset eval. After the fix it passes `['curr']` only.

A mixed-experiment `balanced_acc` case that would have reported `0.5` instead of `0.0` is covered by the new tests.

## Related Issue

Independently discovered. No existing open issue for this; #1127 is a separate import error.

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🆙 Version bump

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/parea-ai/parea-sdk/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/parea-ai/parea-sdk/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.